### PR TITLE
Made 'in c' a bit more usable

### DIFF
--- a/in.cpp
+++ b/in.cpp
@@ -42,8 +42,7 @@ void In::execute(StackMachine *stack)
 		}
 		case character:
 		{
-			char inputvalue;
-			cin >> inputvalue;
+			char inputvalue = cin.get();
 			stack->fStore.push_back(new StackCharacter(inputvalue));
 			break;
 		}


### PR DESCRIPTION
Minor change, but makes reading strings a lot easier. When using the original implementation, you need to juggle around with NULL characters in ways I don't really want to understand. Disadvantage is that it slightly modifies the behaviour of the P machine. Merge if you want ;)